### PR TITLE
fix:Update changelog export code to output list-aware markdown

### DIFF
--- a/Widgets/Changelog.cs
+++ b/Widgets/Changelog.cs
@@ -216,7 +216,7 @@ public sealed class Changelog : Window
             sb.Append("> ");
             for (var i = 0; i < SubText; ++i)
                 sb.Append("  ");
-                
+
             sb.Append("- ");
             if (Color != 0)
                 sb.Append("**");

--- a/Widgets/Changelog.cs
+++ b/Widgets/Changelog.cs
@@ -214,16 +214,14 @@ public sealed class Changelog : Window
         public void Append(StringBuilder sb)
         {
             sb.Append("> ");
-            if (SubText > 0)
-                sb.Append('`');
             for (var i = 0; i < SubText; ++i)
-                sb.Append("    ");
-            if (SubText > 0)
-                sb.Append('`');
+                sb.Append("  ");
+                
+            sb.Append("- ");
             if (Color != 0)
                 sb.Append("**");
-            sb.Append("- ")
-                .Append(Text);
+
+            sb.Append(Text);
             if (Color != 0)
                 sb.Append("**");
 


### PR DESCRIPTION
Since Discord now allows lists (with subsections) in their markdown, this PR gets rid of the spacer inline code. It also moves the starting emphasis marker for **coloured entries** after the list indicator, because the spacing for subsections gets wonky when there are other markdown codes before the list indicator.

I suggest to squash this PR when merging, because no one wants to see my `Fix whitespace` commit that I couldn't magically disappear because I wrote the commits in github.dev.

This code is tested. 