### PR TITLE
Additions for "Material editor 2099"

### DIFF
--- a/Classes/IndexSet.cs
+++ b/Classes/IndexSet.cs
@@ -81,16 +81,22 @@ public class IndexSet : IEnumerable<int>
         return ret;
     }
 
-    public IEnumerator<int> GetEnumerator()
+    /// <summary>
+    /// Gets an enumerable that will return the indices that are either part of this set, or missing from it.
+    /// </summary>
+    /// <param name="complement">false (default) to get the indices that are part of this set, true to get those that are missing from it</param>
+    /// <returns>The index enumerable</returns>
+    public IEnumerable<int> Indices(bool complement = false)
     {
-        if (_count <= 0)
+        var capacity = _set.Count;
+        var remaining = complement ? capacity - _count : _count;
+
+        if (remaining <= 0)
             yield break;
 
-        var capacity  = _set.Count;
-        var remaining = _count;
         for (var i = 0; i < capacity; ++i)
         {
-            if (!_set[i])
+            if (_set[i] == complement)
                 continue;
 
             yield return i;
@@ -100,6 +106,39 @@ public class IndexSet : IEnumerable<int>
         }
     }
 
+    public IEnumerator<int> GetEnumerator()
+        => Indices().GetEnumerator();
+
     IEnumerator IEnumerable.GetEnumerator()
-        => GetEnumerator();
+        => Indices().GetEnumerator();
+
+    /// <summary>
+    /// Gets an enumerable that will return the ranges of indices that are either part of this set, or missing from it.
+    /// </summary>
+    /// <param name="complement">false (default) to get the ranges of indices that are part of this set, true to get those that are missing from it</param>
+    /// <returns>The range enumerable</returns>
+    public IEnumerable<(int Start, int End)> Ranges(bool complement = false)
+    {
+        var capacity = _set.Count;
+        var remaining = complement ? capacity - _count : _count;
+
+        if (remaining <= 0)
+            yield break;
+
+        for (var i = 0; i < capacity; ++i)
+        {
+            if (_set[i] == complement)
+                continue;
+
+            var start = i;
+            while (i < capacity && _set[i] != complement)
+                ++i;
+
+            yield return (start, i);
+
+            remaining -= i - start;
+            if (remaining == 0)
+                yield break;
+        }
+    }
 }

--- a/Util.cs
+++ b/Util.cs
@@ -186,6 +186,25 @@ public static partial class ImGuiUtil
         HoverTooltip(tooltip);
     }
 
+    // Draw a help marker on a selectable, typically for combo box items.
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static void SelectableHelpMarker(string tooltip)
+    {
+        var hovered = ImGui.IsItemHovered();
+        ImGui.SameLine();
+        using (var _ = ImRaii.PushFont(UiBuilder.IconFont))
+        {
+            using var color = ImRaii.PushColor(ImGuiCol.Text, ImGui.GetColorU32(ImGuiCol.TextDisabled));
+            RightAlign(FontAwesomeIcon.InfoCircle.ToIconString(), ImGui.GetStyle().ItemSpacing.X);
+        }
+
+        if (hovered)
+        {
+            using var tt = ImRaii.Tooltip();
+            ImGui.TextUnformatted(tooltip);
+        }
+    }
+
     // Drag between min and max with the given speed and format.
     // Has width of width.
     // Returns true if the item was edited but is not active anymore.


### PR DESCRIPTION
- Add a function that implements the :information_source: that is already used in Penumbra to display option-specific tooltips in the mod settings tab (source: [`Penumbra.UI.ModsTab.ModPanelSettingsTab`](https://github.com/xivdev/Penumbra/blob/3530e139d1d4a3cd1c39a02dcdf5eec15b6de178/Penumbra/UI/ModsTab/ModPanelSettingsTab.cs#L199-L211)) ;
- Add alternate enumerables to `IndexSet` that allow querying:
  - Indices that are part of the set (`foreach (var index in indices)` as already existed),
  - Indices that are not part of the set (`foreach (var index in indices.Indices(complement: true)`),
  - Ranges that are part of the set (`foreach (var (start, end) in indices.Ranges())`),
  - Ranges that are not part of the set (`foreach (var (start, end) in indices.Ranges(complement: true))`).