### PR TITLE
Made FileSystemSelector.Select(Leaf?, bool, TStateStorage) virtual

### DIFF
--- a/Filesystem/Selector/FileSystemSelector.cs
+++ b/Filesystem/Selector/FileSystemSelector.cs
@@ -57,7 +57,7 @@ public partial class FileSystemSelector<T, TStateStorage> where T : class where 
         }
     }
 
-    protected void Select(FileSystem<T>.Leaf? leaf, bool clear, in TStateStorage storage = default)
+    protected virtual void Select(FileSystem<T>.Leaf? leaf, bool clear, in TStateStorage storage = default)
     {
         if (clear)
             _selectedPaths.Clear();


### PR DESCRIPTION
Reasoning for this change:

This allows derived classes to override this method and implement such logic as preventing changing of selected item and notifying user that changing selected item is not allowed at the current time.