### PR TITLE
Add right-side offset for + button in TagButtons

### DIFF
--- a/Widgets/TagButtons.cs
+++ b/Widgets/TagButtons.cs
@@ -23,9 +23,10 @@ public class TagButtons
     /// <param name="editedTag">If the return value is greater or equal to 0, the user input for the tag given by the index.</param>
     /// <param name="editable">Controls if the buttons can be used to edit their tags and if new tags can be added, also controls the background color.</param>
     /// <param name="xOffset">An optional offset that is added after the tag as the text wrap point.</param>
+    /// <param name="rightEndOffset">An optional offset that is used to limit how far from the right-edge of the screen the final button can be placed.</param>
     /// <returns>-1 if no change took place yet, the index of an edited tag (or the count of <paramref name="tags"/> for an added one) if an edit was finalized.</returns>
     public int Draw(string label, string description, IReadOnlyCollection<string> tags, out string editedTag, bool editable = true,
-        float xOffset = 0)
+        float xOffset = 0, float rightEndOffset = 0)
     {
         using var id  = ImRaii.PushId(label);
         var       ret = -1;
@@ -88,7 +89,7 @@ public class TagButtons
         }
         else
         {
-            SetPos(ImGui.GetFrameHeight(), x);
+            SetPos(ImGui.GetFrameHeight(), x, rightEndOffset);
             if (!ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Plus.ToIconString(), new Vector2(ImGui.GetFrameHeight()), "Add Tag...",
                     false, true))
                 return ret;
@@ -110,9 +111,9 @@ public class TagButtons
         _setFocus = false;
     }
 
-    private static float SetPos(float width, float x)
+    private static float SetPos(float width, float x, float rightEndOffset = 0)
     {
-        if (width + ImGui.GetStyle().ItemSpacing.X >= ImGui.GetContentRegionAvail().X)
+        if (width + ImGui.GetStyle().ItemSpacing.X >= ImGui.GetContentRegionAvail().X - rightEndOffset)
         {
             ImGui.NewLine();
             ImGui.SetCursorPosX(x);


### PR DESCRIPTION
## Description

Adds a new parameter to the Draw call in TagButtons.cs that allows for an offset to prevent the + button from being drawn within a certain distance of the right edge of the screen.

This is done to allow elements in different frames to be aligned with the + button vertically without overlapping with it. More specifically, this was done for the new shared tags feature in [xivdev/Penumbra#399](https://github.com/xivdev/Penumbra/pull/399) to allow alignment of the new shared tags button with the existing add tag button.