### PR TITLE
Add HexViewer widget

### DIFF
--- a/Widgets/HexViewer.cs
+++ b/Widgets/HexViewer.cs
@@ -1,0 +1,38 @@
+using Dalamud.Interface;
+using Dalamud.Interface.Utility.Raii;
+using ImGuiNET;
+
+namespace OtterGui.Widgets;
+
+public static partial class Widget
+{
+    private static readonly CompositeFormat ByteHexFormat = CompositeFormat.Parse(" {0:X2}");
+
+    public static void DrawHexViewer(ReadOnlySpan<byte> data)
+    {
+        if (data.Length == 0)
+            return;
+
+        var font = UiBuilder.MonoFont;
+        using var _ = ImRaii.PushFont(font);
+        var emWidth = font.GetCharAdvance('m');
+
+        var addressDigitCount = 8 - (BitOperations.LeadingZeroCount((uint)data.Length - 1) >> 2);
+        var addressFormat = CompositeFormat.Parse($"{{0:X{addressDigitCount}}}:");
+        var charsPerRow = (int)MathF.Floor(ImGui.GetContentRegionAvail().X / emWidth);
+        var bytesPerRow = (charsPerRow - addressDigitCount - 1) / 3;
+        bytesPerRow = 1 << BitOperations.Log2((uint)bytesPerRow);
+
+        var builder = new StringBuilder();
+        for (var rowAddress = 0; rowAddress < data.Length; rowAddress += bytesPerRow)
+        {
+            builder.Clear();
+
+            builder.AppendFormat(null, addressFormat, rowAddress);
+            for (var i = rowAddress; i < data.Length && i < rowAddress + bytesPerRow; i++)
+                builder.AppendFormat(null, ByteHexFormat, data[i]);
+
+            ImGui.TextUnformatted(builder.ToString());
+        }
+    }
+}

--- a/Widgets/HexViewer.cs
+++ b/Widgets/HexViewer.cs
@@ -58,6 +58,8 @@ public static partial class Widget
                 buffer[bufferI++] = @byte is >= 32 and < 127 ? @byte : (byte)'.';
             }
 
+            Debug.Assert(bufferI <= capacity);
+
             ImGuiNative.igTextUnformatted(buffer + (bytesPerRow == data.Length ? 2 : 0), buffer + bufferI);
         }
     }

--- a/Widgets/HexViewer.cs
+++ b/Widgets/HexViewer.cs
@@ -22,8 +22,10 @@ public static partial class Widget
         var addressFormat = CompositeFormat.Parse($"{{0:X{addressDigitCount}}}:");
         var charsPerRow = (int)MathF.Floor(ImGui.GetContentRegionAvail().X / emWidth);
         var bytesPerRow = (charsPerRow - addressDigitCount - 2) / 4;
-        bytesPerRow = 1 << BitOperations.Log2((uint)bytesPerRow);
-        var capacity = addressDigitCount + 2 + 4 * bytesPerRow;
+        bytesPerRow = Math.Min(1 << BitOperations.Log2((uint)bytesPerRow), data.Length);
+        if (bytesPerRow == data.Length)
+            addressDigitCount = 0;
+        var capacity = addressDigitCount + 2 + 4 * bytesPerRow; // address ':' {' ' hex hex} ' ' {printable}
 
         var buffer = stackalloc byte[capacity];
         for (var rowAddress = 0; rowAddress < data.Length; rowAddress += bytesPerRow)
@@ -56,7 +58,7 @@ public static partial class Widget
                 buffer[bufferI++] = @byte is >= 32 and < 127 ? @byte : (byte)'.';
             }
 
-            ImGuiNative.igTextUnformatted(buffer, buffer + bufferI);
+            ImGuiNative.igTextUnformatted(buffer + (bytesPerRow == data.Length ? 2 : 0), buffer + bufferI);
         }
     }
 }


### PR DESCRIPTION
A replacement for this:
```csharp
ImGuiUtil.TextWrapped(string.Join(' ', bytes.Select(c => $"{c:X2}")));
```

But with:
- Better performance (on a 500 kB array, on my machine, `DrawHexViewer` runs at 28 fps, while the line above runs at 4 fps) ;
- Display of printable bytes on the side ;
- Consistent display of 8, 16, 32 (or any other suitable power of two) bytes per row ;
- Offsets in the array displayed as row headers (with as many digits as determined necessary from the array length) ;
- Except for short arrays (one-liners), where the whole array is displayed without header and without power-of-two padding between hex and printable.

Before:
![image](https://github.com/Ottermandias/OtterGui/assets/2236342/4878d2ec-a987-4874-bc6a-13ca91068564)

After:
![image](https://github.com/Ottermandias/OtterGui/assets/2236342/5d9dace5-ff62-471a-88ba-3f59d25f97bf)
